### PR TITLE
Changes that simplify running the tests under Bazel.

### DIFF
--- a/pytest/test_disasm.py
+++ b/pytest/test_disasm.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import pytest
 import re
 
@@ -13,9 +13,6 @@ else:
 def get_srcdir():
     filename = os.path.normcase(os.path.dirname(__file__))
     return os.path.realpath(filename)
-
-src_dir = get_srcdir()
-os.chdir(src_dir)
 
 
 @pytest.mark.parametrize(("test_tuple", "function_to_test"), [
@@ -32,9 +29,10 @@ os.chdir(src_dir)
         disassemble_file,
     ),
 ])
-
 def test_funcoutput(capfd, test_tuple, function_to_test):
-    in_file, filename_expected = test_tuple
+    in_file, filename_expected = [
+        os.path.join(get_srcdir(), p) for p in test_tuple
+    ]
     resout = StringIO()
     function_to_test(in_file, resout)
     expected = "".join(open(filename_expected, "r").readlines())
@@ -47,7 +45,8 @@ def test_funcoutput(capfd, test_tuple, function_to_test):
                  for line in got_lines]
     got = "\n".join(got_lines[5:])
 
-    if got != expected:
-        with open(filename_expected + ".got", "w") as out:
-            out.write(got)
+    if 'XDIS_DONT_WRITE_DOT_GOT_FILES' not in os.environ:
+      if got != expected:
+          with open(filename_expected + ".got", "w") as out:
+              out.write(got)
     assert got == expected


### PR DESCRIPTION
Changed all paths to be absolute, removed `os.chdir` call.  For some
reason `chdir` was not working for me -- I suspect this might be related
to the fact the "current working directory" is a process-global concept,
and it's hard to guarantee that it would not be changed by something in
other thread, or even by the same thread, in the time between module
load and actual test execution.

The way I'm trying to run the tests, it's reading the test data from
read-only mounted partition, so it's not possible to write "*.got" files
near the "*.right" files.  So I added a way
(`XDIS_DONT_WRITE_DOT_GOT_FILES` environment variable) to simple disable
writing those files.