### PR TITLE
Misleading error message when failing to open file (ex: permission denied)

### DIFF
--- a/xdis/load.py
+++ b/xdis/load.py
@@ -102,12 +102,9 @@ def load_module(filename, code_objects=None, fast_load=False,
     elif osp.getsize(filename) < 50:
         raise ImportError("File name: '%s (%d bytes)' is too short to be a valid pyc file" % (filename, osp.getsize(filename)))
 
-    try:
-        fp = open(filename, 'rb')
+    with open(filename, 'rb') as fp:
         return load_module_from_file_object(fp, filename=filename, code_objects=code_objects,
                                             fast_load=fast_load, get_code=get_code)
-    finally:
-        fp.close()
 
 def load_module_from_file_object(fp, filename='<unknown>', code_objects=None, fast_load=False,
                 get_code=True):


### PR DESCRIPTION
When a .pyc file cannot be opened, this is the error message:
    
    Traceback (most recent call last):
      File "/home/jeff/.local/bin/uncompyle6", line 11, in <module>
        sys.exit(main_bin())
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/bin/uncompile.py", line 181, in main_bin
        **options)
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/main.py", line 223, in main
        linemap_stream, do_fragments)
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/main.py", line 126, in decompile_file
        source_size) = load_module(filename, code_objects)
      File "/home/jeff/.local/lib/python2.7/site-packages/xdis/load.py", line 110, in load_module
        fp.close()
    UnboundLocalError: local variable 'fp' referenced before assignment

Changed to use with context handler so that the real exception is raised:

    Traceback (most recent call last):
      File "/home/jeff/.local/bin/uncompyle6", line 11, in <module>
        sys.exit(main_bin())
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/bin/uncompile.py", line 181, in main_bin
        **options)
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/main.py", line 223, in main
        linemap_stream, do_fragments)
      File "/home/jeff/.local/lib/python2.7/site-packages/uncompyle6/main.py", line 126, in decompile_file
        source_size) = load_module(filename, code_objects)
      File "build/bdist.linux-x86_64/egg/xdis/load.py", line 105, in load_module
    IOError: [Errno 13] Permission denied: 'test.pyc'