### PR TITLE
Fix TypeError when unknown magic number is encountered

### DIFF
--- a/xdis/load.py
+++ b/xdis/load.py
@@ -133,7 +133,7 @@ def load_module_from_file_object(fp, filename='<unknown>', code_objects=None, fa
         except KeyError:
             if len(magic) >= 2:
                 raise ImportError("Unknown magic number %s in %s" %
-                                (ord(magic[0])+256*ord(magic[1]), filename))
+                                (ord(magic[0:1])+256*ord(magic[1:2]), filename))
             else:
                 raise ImportError("Bad magic number: '%s'" % magic)
 


### PR DESCRIPTION
Fixes:

```console
$ printf '%99s' > bad.pyc
$ pydisasm bad.pyc
...
Traceback (most recent call last):
  ...
  File ".../xdis/load.py", line 136, in load_module_from_file_object
    (ord(magic[0])+256*ord(magic[1]), filename))
TypeError: ord() expected string of length 1, but int found
```
with Python 3.X.