### PR TITLE
Fix TypeError on Dropbox-hacked bytecode

### DIFF
--- a/xdis/load.py
+++ b/xdis/load.py
@@ -150,7 +150,8 @@ def load_module_from_file_object(fp, filename='<unknown>', code_objects=None, fa
             raise ImportError("%s is a dropbox-hacked Python %s (bytecode %d).\n"
                               "See https://github.com/kholia/dedrop for how to "
                               "decrypt." % (
-                                  filename, magics.magic2int(magic)))
+                                  filename, magics.versions[magic],
+                                  magics.magic2int(magic)))
 
         try:
             # print version


### PR DESCRIPTION
Fixes:

```console
$ printf '\7\363\r\n%99s' > dropbox.pyc
$ pydisasm dropbox.pyc
Traceback (most recent call last):
  ...
  File ".../xdis/load.py", line 153, in load_module_from_file_object
    filename, magics.magic2int(magic)))
TypeError: not enough arguments for format string
```

This bug was found using [pydiatra](https://github.com/jwilk/pydiatra).