### PR TITLE
Fixed DeprecationWarning

### DIFF
--- a/xdis/bytecode.py
+++ b/xdis/bytecode.py
@@ -446,7 +446,7 @@ class Instruction(_Instruction):
                     fields.append('(%s)' % argrepr)
                     argrepr = None
                 elif (self.optype == 'const'
-                      and not re.search('\s', argrepr)):
+                      and not re.search(r'\s', argrepr)):
                     fields.append('(%s)' % argrepr)
                     argrepr = None
                 else:


### PR DESCRIPTION
Fixed warning  `DeprecationWarning: invalid escape sequence \s`.
See https://stackoverflow.com/a/53877976/2142577 for details.