### PR TITLE
Add Python 3.8.10 as a 3.8.x release

### DIFF
--- a/xdis/magics.py
+++ b/xdis/magics.py
@@ -396,7 +396,7 @@ add_canonic_versions(
 )
 add_canonic_versions("3.8.0alpha0 3.8.0alpha3 3.8.0a0", "3.8.0a3+")
 add_canonic_versions(
-    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9",
+    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9 3.8.10",
     "3.8.0rc1+",
 )
 add_canonic_versions(


### PR DESCRIPTION
Python `3.8.10`
Release Date: `May 3, 2021`
Source: https://www.python.org/downloads/release/python-3810/