### PR TITLE
String binary tweak

### DIFF
--- a/xdis/magics.py
+++ b/xdis/magics.py
@@ -402,7 +402,7 @@ add_canonic_versions(
 add_canonic_versions(
     "3.9 3.9.0 3.9.0a1+ 3.9.0a2+ 3.9.0alpha1 3.9.0alpha2", "3.9.0alpha1"
 )
-add_canonic_versions("3.9 3.9.0 3.9.1 3.9.2 3.9.3 3.9.4 3.9.5 3.9.6 3.9.0b5+", "3.9.0beta5")
+add_canonic_versions("3.9 3.9.0 3.9.1 3.9.2 3.9.3 3.9.4 3.9.5 3.9.6 3.9.7 3.9.0b5+", "3.9.0beta5")
 
 # The canonic version for a canonic version is itself
 for v in versions.values():

--- a/xdis/unmarshal.py
+++ b/xdis/unmarshal.py
@@ -344,7 +344,7 @@ class _VersionIndependentUnmarshaller():
         tuplesize = unpack("B", self.fp.read(1))[0]
         ret, i = self.r_ref_reserve(tuple(), save_ref)
         while tuplesize > 0:
-            ret += (self.r_object(),)
+            ret += (self.r_object(bytes_for_s=bytes_for_s),)
             tuplesize -= 1
             pass
         return self.r_ref_insert(ret, i)
@@ -451,9 +451,9 @@ class _VersionIndependentUnmarshaller():
             co_flags = 0
 
         co_code = self.r_object(bytes_for_s=True)
-        # FIXME: think about whether this is true:
-        # bytes_for_s = PYTHON_VERSION >= 3.0 and version > 3.0
-        co_consts = self.r_object(bytes_for_s=True)
+        # FIXME: Check/verify that is true:
+        bytes_for_s = PYTHON_VERSION >= 3.0 and version > 3.0
+        co_consts = self.r_object(bytes_for_s=bytes_for_s)
         co_names = self.r_object()
 
         if version >= 1.3:

--- a/xdis/unmarshal.py
+++ b/xdis/unmarshal.py
@@ -382,9 +382,6 @@ class _VersionIndependentUnmarshaller():
             setsize -= 1
         return self.r_ref_insert(set(ret), i)
 
-    def t_int32(self, save_ref, bytes_for_s=None):
-        return self.r_ref(int(unpack("<i", self.fp.read(4))[0]), save_ref)
-
     def t_dict(self, save_ref, bytes_for_s=None):
         ret = self.r_ref(dict(), save_ref)
         # dictionary
@@ -454,7 +451,8 @@ class _VersionIndependentUnmarshaller():
             co_flags = 0
 
         co_code = self.r_object(bytes_for_s=True)
-        bytes_for_s = PYTHON_VERSION >= 3.0 and version > 3.0
+        # FIXME: think about whether this is true:
+        # bytes_for_s = PYTHON_VERSION >= 3.0 and version > 3.0
         co_consts = self.r_object(bytes_for_s=True)
         co_names = self.r_object()
 


### PR DESCRIPTION
- Add 3.9.7 
-  Remove duplicate method in unmarshal 
-  Fix bug in detecting bytes in Python 3.x
