### PR TITLE
Remove 3.6+ type annotation

### DIFF
--- a/xdis/unmarshal.py
+++ b/xdis/unmarshal.py
@@ -96,7 +96,7 @@ UNMARSHAL_DISPATCH_TABLE = {
 }
 
 
-def compat_str(s: str) -> str:
+def compat_str(s) -> str:
     """
     This handles working with strings between Python2 and Python3.
     """


### PR DESCRIPTION
This causes installation using pip to fail, a regression from 5.0.12. It looks like the change was made in https://github.com/rocky/python-xdis/commit/154e85761681ca61ee350b86ab85efd90b37e9ab which itself is a reversion of https://github.com/rocky/python-xdis/commit/5fc383dbe3fe75be11cbfd0f3762ecc746982732.