### PR TITLE
Fixup for python Code3 vs Code2

### DIFF
--- a/xdis/marsh.py
+++ b/xdis/marsh.py
@@ -105,11 +105,11 @@ class _Marshaller:
         try:
             self.dispatch[type(x)](self, x)
         except KeyError:
-            if isinstance(x, Code2):
-                self.dispatch[Code2](self, x)
-                return
-            elif isinstance(x, Code3):
+            if isinstance(x, Code3):
                 self.dispatch[Code3](self, x)
+                return
+            elif isinstance(x, Code2):
+                self.dispatch[Code2](self, x)
                 return
             else:
                 for tp in type(x).mro():


### PR DESCRIPTION
This code (line 108) will always execure Code2 condition because Code3 is an inheritor of Code2. This way you cannot dump code object of Code38 (it has `co_posonlyargcount`) properly - generated code object will be broken.

```python3
            if isinstance(x, Code2): # always True for Code2, Code3, Code38
                self.dispatch[Code2](self, x)
                return
            elif isinstance(x, Code3): # will never work because previous condition overlaps it
                self.dispatch[Code3](self, x)
                return
```

So, this fix will solve the problem with saving Code38 code objects to pyc