### PR TITLE
Add newest versions 3.7.13, 3.8.13, 3.9.11, and 3.10.3 in magics

### DIFF
--- a/admin-tools/pyenv-newest-versions
+++ b/admin-tools/pyenv-newest-versions
@@ -5,4 +5,4 @@ if [[ $0 == ${BASH_SOURCE[0]} ]] ; then
     echo "This script should be *sourced* rather than run directly through bash"
     exit 1
 fi
-export PYVERSIONS='3.6.15 pypy3.6-7.3.0 3.7.12 pypy3.7-7.3.7 pyston-2.3.2 3.7.12 3.8.12 3.9.10 3.10.2'
+export PYVERSIONS='3.6.15 pypy3.6-7.3.0 3.7.12 pypy3.7-7.3.7 pyston-2.3.2 3.7.13 3.8.13 3.9.11 3.10.3'

--- a/xdis/magics.py
+++ b/xdis/magics.py
@@ -417,22 +417,22 @@ add_canonic_versions("2.7.8Pyston", "2.7.7Pyston")
 add_canonic_versions("3.7.0alpha3", "3.7.0alpha3")
 add_canonic_versions(
     "3.7 3.7.0beta5 3.7.1 3.7.2 3.7.3 3.7.4 3.7.5 3.7.6 3.7.7 3.7.8 3.7.9 "
-    "3.7.10 3.7.11 3.7.12",
+    "3.7.10 3.7.11 3.7.12 3.7.13",
     "3.7.0",
 )
 add_canonic_versions("3.8.0alpha0 3.8.0alpha3 3.8.0a0", "3.8.0a3+")
 add_canonic_versions(
-    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9 3.8.10 3.8.11 3.8.12",
+    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9 3.8.10 3.8.11 3.8.12 3.8.13",
     "3.8.0rc1+",
 )
 add_canonic_versions(
     "3.9 3.9.0 3.9.0a1+ 3.9.0a2+ 3.9.0alpha1 3.9.0alpha2", "3.9.0alpha1"
 )
 add_canonic_versions(
-    "3.9 3.9.0 3.9.1 3.9.2 3.9.3 3.9.4 3.9.5 3.9.6 3.9.7 3.9.8 3.9.9 3.9.10 3.9.0b5+", "3.9.0beta5"
+    "3.9 3.9.0 3.9.1 3.9.2 3.9.3 3.9.4 3.9.5 3.9.6 3.9.7 3.9.8 3.9.9 3.9.10 3.9.11 3.9.0b5+", "3.9.0beta5"
 )
 
-add_canonic_versions("3.10 3.10.0 3.10.1 3.10.2", "3.10.0rc2")
+add_canonic_versions("3.10 3.10.0 3.10.1 3.10.2 3.10.3", "3.10.0rc2")
 
 # The canonic version for a canonic version is itself
 for v in versions.values():


### PR DESCRIPTION
Hi, there are [new versions](https://www.python.org/doc/versions/) of Python released on 16.3.2022. Can you please add them into the known versions so `xdis` will know them and will not fail when it will run on any of them?