### PR TITLE
opc.l -> opc.loc

### DIFF
--- a/xdis/opcodes/opcode_10.py
+++ b/xdis/opcodes/opcode_10.py
@@ -42,7 +42,7 @@ from xdis.opcodes.base import (  # Although these aren't used here, they are exp
 version_tuple = (1, 0)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_11, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_11.py
+++ b/xdis/opcodes/opcode_11.py
@@ -40,7 +40,7 @@ from xdis.opcodes.base import (  # Although these aren't used here, they are exp
 version_tuple = (1, 1)  # 1.2 is the same
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_12, version_tuple)
 
 update_pj2(globals(), l)

--- a/xdis/opcodes/opcode_12.py
+++ b/xdis/opcodes/opcode_12.py
@@ -43,7 +43,7 @@ from xdis.opcodes.base import (  # Although these aren't used here, they are exp
 version_tuple = (1, 2)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_13, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_13.py
+++ b/xdis/opcodes/opcode_13.py
@@ -41,7 +41,7 @@ from xdis.opcodes.base import (  # Although these aren't used here, they are exp
 version_tuple = (1, 3)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_14, version_tuple)
 
 # 1.3 - 1.4 bytecodes differences

--- a/xdis/opcodes/opcode_14.py
+++ b/xdis/opcodes/opcode_14.py
@@ -40,7 +40,7 @@ from xdis.opcodes.base import (  # Although these aren't used here, they are exp
 version_tuple = (1, 4)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_15, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_15.py
+++ b/xdis/opcodes/opcode_15.py
@@ -67,7 +67,7 @@ cmp_op = (
 # as opcode.py likes to call it.
 HAVE_ARGUMENT = 90
 
-l = locals()
+loc = l = locals()
 l["python_version"] = version_tuple
 l["cmp_op"] = cmp_op
 l["HAVE_ARGUMENT"] = HAVE_ARGUMENT

--- a/xdis/opcodes/opcode_16.py
+++ b/xdis/opcodes/opcode_16.py
@@ -40,7 +40,7 @@ from xdis.opcodes.base import (
 version_tuple = (1, 6)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_15, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_20.py
+++ b/xdis/opcodes/opcode_20.py
@@ -36,7 +36,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 0)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_21, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_21.py
+++ b/xdis/opcodes/opcode_21.py
@@ -35,7 +35,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 1)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_22, version_tuple)
 
 # 2.1 bytecodes changes from 2.2

--- a/xdis/opcodes/opcode_22.py
+++ b/xdis/opcodes/opcode_22.py
@@ -21,7 +21,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 2)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_2x, version_tuple)
 
 # 2.2 Bytecodes not in 2.3

--- a/xdis/opcodes/opcode_23.py
+++ b/xdis/opcodes/opcode_23.py
@@ -25,7 +25,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 3)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_2x, version_tuple)
 
 update_pj2(globals(), l)

--- a/xdis/opcodes/opcode_24.py
+++ b/xdis/opcodes/opcode_24.py
@@ -26,7 +26,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 4)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_2x, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_25.py
+++ b/xdis/opcodes/opcode_25.py
@@ -26,7 +26,7 @@ from xdis.opcodes.base import (
 version_tuple = (2, 5)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_24, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_26.py
+++ b/xdis/opcodes/opcode_26.py
@@ -43,7 +43,7 @@ python_implementation = "CPython"
 
 version_tuple = (2, 6)
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_25, version_tuple)
 
 # Below are opcode changes since Python 2.5

--- a/xdis/opcodes/opcode_27.py
+++ b/xdis/opcodes/opcode_27.py
@@ -43,11 +43,10 @@ from xdis.opcodes.base import (
     varargs_op,
 )
 
-version = 2.7
 version_tuple = (2, 7)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_26, version_tuple)
 
 # fmt: off

--- a/xdis/opcodes/opcode_27pypy.py
+++ b/xdis/opcodes/opcode_27pypy.py
@@ -30,7 +30,7 @@ version = 2.7
 version_tuple = (2, 7)
 python_implementation = "PyPy"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_27, version_tuple, is_pypy=True)
 

--- a/xdis/opcodes/opcode_30.py
+++ b/xdis/opcodes/opcode_30.py
@@ -26,7 +26,7 @@ from xdis.opcodes.opcode_3x import (
 version_tuple = (3, 0)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_31, version_tuple)
 

--- a/xdis/opcodes/opcode_31.py
+++ b/xdis/opcodes/opcode_31.py
@@ -23,9 +23,8 @@ from xdis.opcodes.opcode_3x import (
     format_MAKE_FUNCTION_30_35,
 )
 
-l = locals()
+loc = l = locals()
 
-version = 3.1
 version_tuple = (3, 1)
 python_implementation = "CPython"
 

--- a/xdis/opcodes/opcode_310.py
+++ b/xdis/opcodes/opcode_310.py
@@ -41,11 +41,10 @@ from xdis.opcodes.opcode_36 import (
 )
 from xdis.opcodes.opcode_37 import extended_format_RAISE_VARARGS, format_RAISE_VARARGS
 
-version = 3.10
 version_tuple = (3, 10)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_39, version_tuple)
 

--- a/xdis/opcodes/opcode_32.py
+++ b/xdis/opcodes/opcode_32.py
@@ -26,11 +26,10 @@ from xdis.opcodes.opcode_3x import (
 
 # FIXME: can we DRY this even more?
 
-version = 3.2
 version_tuple = (3, 2)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_3x, version_tuple)
 

--- a/xdis/opcodes/opcode_33.py
+++ b/xdis/opcodes/opcode_33.py
@@ -24,7 +24,7 @@ from xdis.opcodes.base import (
 version_tuple = (3, 3)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 init_opdata(l, opcode_3x, version_tuple)
 
 # Below are opcode changes since Python 3.2

--- a/xdis/opcodes/opcode_34.py
+++ b/xdis/opcodes/opcode_34.py
@@ -28,7 +28,7 @@ from xdis.opcodes.opcode_3x import (
 version_tuple = (3, 4)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_33, version_tuple)
 

--- a/xdis/opcodes/opcode_35.py
+++ b/xdis/opcodes/opcode_35.py
@@ -45,7 +45,7 @@ from xdis.opcodes.opcode_3x import (
 version_tuple = (3, 5)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_34, version_tuple)
 

--- a/xdis/opcodes/opcode_36.py
+++ b/xdis/opcodes/opcode_36.py
@@ -46,7 +46,6 @@ oppop = {}
 # Note: this changes in Python 3.6
 EXTENDED_ARG_SHIFT = 8
 
-version = 3.6
 version_tuple = (3, 6)
 python_implementation = "CPython"
 

--- a/xdis/opcodes/opcode_38.py
+++ b/xdis/opcodes/opcode_38.py
@@ -45,7 +45,7 @@ from xdis.opcodes.opcode_36 import (
 version_tuple = (3, 8)
 python_implementation = "CPython"
 
-l = locals()
+loc = l = locals()
 
 init_opdata(l, opcode_37, version_tuple)
 

--- a/xdis/opcodes/opcode_3x.py
+++ b/xdis/opcodes/opcode_3x.py
@@ -40,7 +40,7 @@ from xdis.opcodes.base import (
     varargs_op,
 )
 
-l = locals()
+loc = l = locals()
 
 # FIXME: DRY with opcode2x.py
 


### PR DESCRIPTION
Pylint doesn't like opc.l since "l" can be confused with 1.

We haven't converted all of the places to rename opc.l to opc.loc. In the meantime we will just add "loc" as another name for "l".

Also, remove more remnants of opc.version - use opc.version_tuple instead.