### PR TITLE
3.11 Fix calculation of JUMP_BACKWARD jump target.

### DIFF
--- a/xdis/bytecode.py
+++ b/xdis/bytecode.py
@@ -251,7 +251,11 @@ def get_instructions_bytes(
                     argval, argrepr = _get_name_info(arg, names)
                 optype = "name"
             elif op in opc.JREL_OPS:
-                argval = i + get_jump_val(arg, opc.python_version)
+                if opc.version_tuple >= (3,11) and 'JUMP_BACKWARD' in opc.opname[op]:
+                    argval = i + -get_jump_val(arg, opc.python_version)
+                else:
+                    argval = i + get_jump_val(arg, opc.python_version)
+
                 argrepr = "to " + repr(argval)
                 optype = "jrel"
             elif op in opc.JABS_OPS:

--- a/xdis/opcodes/base.py
+++ b/xdis/opcodes/base.py
@@ -265,7 +265,7 @@ def update_sets(loc):
             [loc["opmap"]["JUMP_ABSOLUTE"], loc["opmap"]["JUMP_FORWARD"]]
         )
     else:
-        loc["JUMP_UNCONDITONAL"] = frozenset([loc["opmap"]["JUMP_FORWARD"]])
+        loc["JUMP_UNCONDITONAL"] = frozenset([loc["opmap"]["JUMP_FORWARD"], loc["opmap"]["JUMP_BACKWARD"]])
     if PYTHON_VERSION_TRIPLE < (3, 8, 0) and loc["python_version"] < (3, 8):
         loc["LOOP_OPS"] = frozenset([loc["opmap"]["SETUP_LOOP"]])
     else:


### PR DESCRIPTION
Previously `JUMP_BACKWARD` jump targets were not being calculated in the correct spot. This would result in these instructions acting as a `JUMP_FORWARD`.

_Example_
```python
148 JUMP_BACKWARD (to 184)

# now

148 JUMP_BACKWARD (to 112) 
```

Also added `JUMP_BACKWARD` to the unconditional jumps table for 3.11.