### PR TITLE
3.11 BINARY_OP arg formatting and change order of op definitions

### DIFF
--- a/xdis/opcodes/opcode_311.py
+++ b/xdis/opcodes/opcode_311.py
@@ -177,6 +177,37 @@ def format_extended_contains_op(arg):
     return "in" if arg == 0 else "not in"
 
 
+def format_BINARY_OP(arg):
+    _nb_ops = [
+        ("NB_ADD", "+"),
+        ("NB_AND", "&"),
+        ("NB_FLOOR_DIVIDE", "//"),
+        ("NB_LSHIFT", "<<"),
+        ("NB_MATRIX_MULTIPLY", "@"),
+        ("NB_MULTIPLY", "*"),
+        ("NB_REMAINDER", "%"),
+        ("NB_OR", "|"),
+        ("NB_POWER", "**"),
+        ("NB_RSHIFT", ">>"),
+        ("NB_SUBTRACT", "-"),
+        ("NB_TRUE_DIVIDE", "/"),
+        ("NB_XOR", "^"),
+        ("NB_INPLACE_ADD", "+="),
+        ("NB_INPLACE_AND", "&="),
+        ("NB_INPLACE_FLOOR_DIVIDE", "//="),
+        ("NB_INPLACE_LSHIFT", "<<="),
+        ("NB_INPLACE_MATRIX_MULTIPLY", "@="),
+        ("NB_INPLACE_MULTIPLY", "*="),
+        ("NB_INPLACE_REMAINDER", "%="),
+        ("NB_INPLACE_OR", "|="),
+        ("NB_INPLACE_POWER", "**="),
+        ("NB_INPLACE_RSHIFT", ">>="),
+        ("NB_INPLACE_SUBTRACT", "-="),
+        ("NB_INPLACE_TRUE_DIVIDE", "/="),
+        ("NB_INPLACE_XOR", "^="),
+    ]
+    return _nb_ops[arg][1]
+
 
 opcode_arg_fmt = {
     "CALL_FUNCTION_EX": format_CALL_FUNCTION_EX,
@@ -187,6 +218,7 @@ opcode_arg_fmt = {
     "IS_OP": format_extended_is_op,
     "MAKE_FUNCTION": format_MAKE_FUNCTION,
     "RAISE_VARARGS": format_RAISE_VARARGS,
+    "BINARY_OP": format_BINARY_OP,
 }
 
 opcode_extended_fmt = {

--- a/xdis/opcodes/opcode_311.py
+++ b/xdis/opcodes/opcode_311.py
@@ -97,7 +97,12 @@ rm_op(l,  "YIELD_FROM",              72)
 # match, these two ops had stack effects changed
 rm_op(l,  "MATCH_CLASS",            152)
 rm_op(l,  "MATCH_KEYS",              33)
-
+# ops redefined later
+rm_op(l, "STORE_DEREF",                     137)
+rm_op(l, "LOAD_DEREF",                      136)
+rm_op(l, "DELETE_DEREF",                    138)
+rm_op(l, "GET_AWAITABLE",                    73)
+rm_op(l, "LOAD_CLOSURE",                    135)
 
 # These are added since 3.10...
 #          OP NAME                         OPCODE  POP PUSH
@@ -149,19 +154,10 @@ jrel_op(l, "PUSH_EXC_INFO",                  35,   0, 1)
 def_op(l, "RESUME",                         151,   0, 0)
 
 ## Redefined OPS
-rm_op(l, "STORE_DEREF",                     137)
 def_op(l, "STORE_DEREF",                    138,   1, 0)
-
-rm_op(l, "LOAD_DEREF",                      136)
 def_op(l, "LOAD_DEREF",                     137,   0, 1)
-
-rm_op(l, "DELETE_DEREF",                    138)
 def_op(l, "DELETE_DEREF",                   139,   0, 0)
-
-rm_op(l, "GET_AWAITABLE",                    73)
 def_op(l, "GET_AWAITABLE",                  131,   0, 0)
-
-rm_op(l, "LOAD_CLOSURE",                    135)
 def_op(l, "LOAD_CLOSURE",                   136,   0, 1)
 
 ## Update tables 


### PR DESCRIPTION
__BINARY_OP arg formatting__
Previously binary_op's arguments were not being correctly output. Needed to use table from dis to get correct argrepr.

__Op definition order__
The order in which I wrote the definition of the ops resulted in cases of collisions between ops with the same opcodes being overwritten incorrectly.
Previously this means that `MAKE_CELL` and `STORE_DEREF` were not defined.