### PR TITLE
Removed self-reference from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ name = "xdis"
 description = "Python cross-version byte-code library and disassembler"
 dependencies = [
     "click",
-    "xdis >= 6.0.0, < 6.2.0",
     "six >= 1.10.0",
 ]
 readme = "README.rst"


### PR DESCRIPTION
Removed `xdis` from the list of package dependencies within `pyproject.toml` (circular dependency). PR implementing https://github.com/rocky/python-xdis/issues/132