### PR TITLE
Fix crazy [Access is denied] error on TC run on Windows OS

### DIFF
--- a/xdis/load.py
+++ b/xdis/load.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import types
 from datetime import datetime
+from os import close
 from struct import pack, unpack
 
 import xdis.marsh
@@ -84,7 +85,8 @@ def check_object_path(path):
             spath = path
         else:
             spath = path.decode("utf-8")
-        path = tempfile.mkstemp(prefix=basename + "-", suffix=".pyc", text=False)[1]
+        fd, path = tempfile.mkstemp(prefix=basename + "-", suffix=".pyc", text=False)
+        close(fd)
         py_compile.compile(spath, cfile=path, doraise=True)
 
     if not is_bytecode_extension(path):


### PR DESCRIPTION
this PR fixes the issue seen in #138 under Windows:

```
Traceback (most recent call last):
  File "c:\Dev\python\python-xdis-orig\test\test_pyenvlib.py", line 266, in <module>
    do_tests(
  File "c:\Dev\python\python-xdis-orig\test\test_pyenvlib.py", line 185, in do_tests
    check_bc_file = check_object_path(bc_file)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\AppData\Local\Programs\Python\Python312\Lib\site-packages\xdis\load.py", line 89, in check_object_path
    py_compile.compile(spath, cfile=path)
  File "C:\Users\user\AppData\Local\Programs\Python\Python312\Lib\py_compile.py", line 172, in compile
    importlib._bootstrap_external._write_atomic(cfile, bytecode, mode)
  File "<frozen importlib._bootstrap_external>", line 208, in _write_atomic
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\user\\AppData\\Local\\Temp\\06_frozenset-m0zxlh9_.pyc.20330544' -> 'C:\\Users\\user\\AppData\\Local\\Temp\\06_frozenset-m0zxlh9_.pyc'
```

come into my head after reading some Python issues/conversations, eg:
https://bugs.python.org/issue46003

