### PR TITLE
Fix dumping co_varnames

### DIFF
--- a/xdis/marsh.py
+++ b/xdis/marsh.py
@@ -327,7 +327,12 @@ class _Marshaller:
         for name in x.co_names:
             self.dump_string(name)
 
-        self.dump(x.co_varnames)
+        # The tuple "varnames" in Python2 also must have string entries
+        self._write(TYPE_TUPLE)
+        self.w_long(len(x.co_varnames))
+        for name in x.co_varnames:
+            self.dump_string(name)
+
         self.dump(x.co_freevars)
         self.dump(x.co_cellvars)
         self.dump_string(x.co_filename)


### PR DESCRIPTION
When dumping Code2 object, it will dump members of `co_varnames` as unicode. But they also should be string entries like `co_names`.

<img width="559" alt="image" src="https://github.com/user-attachments/assets/46d0872b-440c-4618-8a5d-ebd61ca62c13">

If they're unicode, uncompyle6 will treat them as bytes, and the decompilation output will be inappropriate like (the code object corresponding to the binary in the above figure):

```python
# python2.7 code
    def __init__(b'O_O', b'o_O', b'OwOO_O', b'O_OO_O', b'o_OO_O'):
        O_O.o_O = o_O
        O_O.OwOO_O = OwOO_O
        O_O.O_OO_O = O_OO_O
        O_O.o_OO_O = o_OO_O
```
It must be:

```python
    def __init__(O_O, o_O, OwOO_O, O_OO_O, o_OO_O):
        O_O.o_O = o_O
        O_O.OwOO_O = OwOO_O
        O_O.O_OO_O = O_OO_O
        O_O.o_OO_O = o_OO_O
```

In my opinion, the modification should be done on the xdis side, because co_varnames and co_names are both variable names. 
Thank you for such an awesome and useful tool!