### PR TITLE
fix: forgotten 'labels' parameter

### DIFF
--- a/xdis/bytecode.py
+++ b/xdis/bytecode.py
@@ -491,6 +491,7 @@ def get_instructions_bytes(
                 linestarts=linestarts,
                 line_offset=0,
                 exception_entries=exception_entries,
+                labels=labels
             )
         )
 


### PR DESCRIPTION
In file `bytecode.py` in function `get_instructions_bytes`, `labels` is computed but not passed to `get_logical_instruction_at_offset`.
As a result, a drastic decrease of performance for certain large files, as `get_logical_instruction_at_offset` has to recalculate labels every iteration.
(Example: up to x50 speedup for sims4 generated.zip decompilation ~4 minutes-> ~4-5 seconds)