### PR TITLE
fix merge issues from PR 174

### DIFF
--- a/xdis/opcodes/opcode_314.py
+++ b/xdis/opcodes/opcode_314.py
@@ -3,6 +3,7 @@ CPython 3.14 bytecode opcodes
 """
 
 from xdis.opcodes.base import (
+    cpython_implementation as python_implementation,
     init_opdata,
     binary_op,
     call_op,

--- a/xdis/unmarshal.py
+++ b/xdis/unmarshal.py
@@ -800,8 +800,8 @@ class _VersionIndependentUnmarshaller:
 
         co_exceptiontable = None
 
-        if self.version_tuple >= (1, 5):
-            if self.version_tuple >= (2, 3):
+        if self.version_triple >= (1, 5):
+            if self.version_triple >= (2, 3):
                 co_firstlineno = unpack("<i", self.fp.read(4))[0]
             else:
                 co_firstlineno = unpack("<h", self.fp.read(2))[0]


### PR DESCRIPTION
This fixes a couple issues that entered in the merge with the Graal stuff in the python-3.14 branch:
- `version_tuple` was renamed to `version_triple` in `unmarshal.py`
- opcodes now need to specify their Python implementation