### PR TITLE
WIP: Crossversion Testing

### DIFF
--- a/test_crossversion/Makefile
+++ b/test_crossversion/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean get_sources setup_pyenv compile prepare test 
+.PHONY: help clean get_sources setup_pyenv setup_uv compile prepare .prepare_msg test .mkdirs
 
 SOURCE=./templates/source/
 COMPILED=./templates/compiled/
@@ -29,18 +29,23 @@ clean:
 	rm -rf $(COMPILED)/*
 	rm -rf $(SERIALIZED)/*
 
+.mkdirs:
+	mkdir -p "$(SOURCE)" "$(COMPILED)" "$(SERIALIZED)"
+
 #: copy all .py files in ./ -> ./templates/source/
 get_sources:
 	cp -f *.py $(SOURCE)
 
 .python-version:
 	tox --listenvs | xargs pyenv local
+
 #: setup local pyenv versions to be used by tox
-setup_pyenv: .python-version
+setup_pyenv: .mkdirs .python-version
 
 #: setup tox-uv so tox can use uv
-setup_uv:
+setup_uv: .mkdirs
 	uv tool install tox --with tox-uv
+	tox --listenvs | xargs uv python install
 
 #: with each tox env, compile all sources in ./templates/source/ to ./templates/compiled/, then serialize with dis to ./templates/serialized/
 compile:

--- a/test_crossversion/Makefile
+++ b/test_crossversion/Makefile
@@ -34,7 +34,7 @@ clean:
 
 #: copy all .py files in ./ -> ./templates/source/
 get_sources:
-	cp -f *.py $(SOURCE)
+	cp $(shell find . -name "*.py" | head -n 10 | xargs) $(SOURCE)
 
 .python-version:
 	tox --listenvs | xargs pyenv local

--- a/test_crossversion/USAGE.md
+++ b/test_crossversion/USAGE.md
@@ -1,11 +1,11 @@
 # Automated crossversion testing
 This testing suite is used for automatic testing of differences found between xdis and dis.
-This is done by having a way to identically "serialize" important attributes in xdis and dis bytecodes.
-We then can check a diff between a serialized xdis and dis bytecode to find if xdis is parsing something incorrectly.
+This is done by having a way to identically "serialize" important attributes in bytecodes with xdis and dis.
+Using a diff between a bytecode serialized with xdis and dis, we can find if xdis is parsing something incorrectly.
 Most tests should be ran using the makefile.
 
 # Parsing results
-When running `make test`, tox will serialize bytecode to be put into text form. Given a bytecode compiled in 3.11 and natively disassembled, we go through each of our test versions, say 3.9 ... 3.14, and disassemble the same 3.11 bytecode.
+When running `make test`, two main steps take place. 1st, we compile and serialize bytecode in each target version. 2nd, we disasm the same bytecode using xdis, serialize again, and check the diff. In other words, given a bytecode compiled in 3.11 and natively disassembled (dis), we go through each of our test versions, say 3.9 ... 3.14, and disassemble the same 3.11 bytecode.
 Given the 3.11 serialized disasembly, disassembled from 3.11, we take the diff between that and a serialized 3.11 disassembled from any of our test versions.
 This lets us see if there are any differences in how xdis handles native vs cross version.
 
@@ -22,18 +22,20 @@ for native in test_vers:
 
 Pytest will fail early, so not all tests may be ran.
 
-# System Requirements
+# Usage
+## Requirements
 - `uv`
     - uv will handle everything on its own
+run `make setup_uv`
 
 ---OR---
 
 - `pyenv` and `pyenv-virtualenv`
     - Each version needing to be tested should be installed with pyenv
 - `tox`
+run `make setup_pyenv`
 
-# Usage
-## Makefile
+## Running tests
 Run `make` or `make help` to show the help menu for running and preparing tests, or with `remake`, `remake --tasks`.
 
 To simply run tests, `make test` will copy some sources, prepare template files, and run tests.

--- a/test_crossversion/test_xdis.py
+++ b/test_crossversion/test_xdis.py
@@ -30,7 +30,7 @@ class SerializedTestCase:
         self.serialized_xdis = serialize_pyc(pyc, use_xdis=True, output_file=None)
         # debug messages
         self.message = f"{SYS_VERSION}: Checking equivalence: {self.pyc_path} <---> {self.serialized_txt_path}"
-        self.fail_message = f"{SYS_VERSION} failed equivalence; xdis:{self.pyc_path.name} != dis:{self.serialized_txt_path.name}"
+        self.fail_message = f"Running version {SYS_VERSION}, failed equivalence; xdis:{self.pyc_path.name} != dis:{self.serialized_txt_path.name}"
 
     def __str__(self) -> str:
         return self.message

--- a/test_crossversion/test_xdis.py
+++ b/test_crossversion/test_xdis.py
@@ -28,8 +28,9 @@ class SerializedTestCase:
         # read serialized bytecode
         self.serialized_dis = serialized_txt.read_text()
         self.serialized_xdis = serialize_pyc(pyc, use_xdis=True, output_file=None)
-        # debug message
+        # debug messages
         self.message = f"{SYS_VERSION}: Checking equivalence: {self.pyc_path} <---> {self.serialized_txt_path}"
+        self.fail_message = f"{SYS_VERSION} failed equivalence; xdis:{self.pyc_path.name} != dis:{self.serialized_txt_path.name}"
 
     def __str__(self) -> str:
         return self.message
@@ -64,7 +65,7 @@ def get_tests_by_version(v: str) -> Iterable[SerializedTestCase]:
 def test_version(version):
     """Test each version in compiled template folder."""
     for case in get_tests_by_version(version):
-        assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines()
+        assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines(), case.fail_message
 
 
 ### LESS VERBOSE (fail early) ###
@@ -72,4 +73,4 @@ def test_version(version):
 #    "case", chain.from_iterable(get_tests_by_version(v) for v in get_versions())
 #)
 #def test_case(case: SerializedTestCase) -> None:
-#    assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines()
+#    assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines(), case.fail_message


### PR DESCRIPTION
I improved cross version testing, and think it may be ready for development use. It is currently quite strict, so finds very small discrepancies between dis and xdis. I think with a little more work it could be used to automatically find changes and differences when adding new versions of python to xdis; and make sure they still work with older versions of python.

Here is an example output of a test run. This automatically finds a couple minor difference in xdis and dis.
1. Running xdis on 3.14, disassembling a 3.14 bytecode, xdis's argval is `0` while dis's argval is `<`.
2. Running xdis on 3.14, disassembling a 3.12 bytecode, xdis's argval is `0` while dis's argval is `(None, False)` 
3. Running xdis on 3.12, disassembling a 3.13 bytecode, there is a difference in the constants table (truncated length)

```
_____________________________________________________________________________________ test_version[3.14] ______________________________________________________________________________________

version = '3.14'

    @pytest.mark.parametrize("version", get_versions())
    def test_version(version):
        """Test each version in compiled template folder."""
        for case in get_tests_by_version(version):
>           assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines(), case.fail_message
E           AssertionError: Running version 3.14, failed equivalence; xdis:core_3.14.pyc != dis:core_3.14.txt
E           assert ['BYTECODE <m...None,)]', ...] == ['BYTECODE <m...None,)]', ...]
E
E             At index 1129 diff: '74 IS_OP : 0 0' != '74 IS_OP : 0 <'
E             Use -v to get more diff

test_xdis.py:68: AssertionError
_____________________________________________________________________________________ test_version[3.12] ______________________________________________________________________________________

version = '3.12'

    @pytest.mark.parametrize("version", get_versions())
    def test_version(version):
        """Test each version in compiled template folder."""
        for case in get_tests_by_version(version):
>           assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines(), case.fail_message
E           AssertionError: Running version 3.14, failed equivalence; xdis:serialize_bytecode_3.12.pyc != dis:serialize_bytecode_3.12.txt
E           assert ['BYTECODE <m...'str')]", ...] == ['BYTECODE <m...'str')]", ...]
E
E             At index 429 diff: '155 FORMAT_VALUE : 0 (None, False)' != '155 FORMAT_VALUE : 0 0'
E             Use -v to get more diff

test_xdis.py:68: AssertionError
_____________________________________________________________________________________ test_version[3.13] ______________________________________________________________________________________

version = '3.13'

    @pytest.mark.parametrize("version", get_versions())
    def test_version(version):
        """Test each version in compiled template folder."""
        for case in get_tests_by_version(version):
>           assert case.serialized_dis.splitlines() == case.serialized_xdis.splitlines(), case.fail_message
E           AssertionError: Running version 3.14, failed equivalence; xdis:_compat_3.13.pyc != dis:_compat_3.13.txt
E           assert ['BYTECODE <m...one]')]", ...] == ['BYTECODE <m...one]')]", ...]
E
E             At index 1356 diff: 'consts : [None, \'b\', \'-\', \'<codeobj <genexpr>\', (\'w\', \'a\', \'x\'), False, (\'encoding\'
E
E             ...Full output truncated (2 lines hidden), use '-vv' to show

test_xdis.py:68: AssertionError
```

@rocky @jdw170000 thoughts?