### PR TITLE
Add PycModuleInfo object for returning from load_module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+* Add `PycModuleInfo` object for loaded module instead of tuple
+
+
 6.3.0 2026-03-30 Your Conference listed here
 ============================================
 

--- a/pytest/test_bytecode.py
+++ b/pytest/test_bytecode.py
@@ -129,8 +129,8 @@ def findlabels():
         assert offsets == [26, 25, 16]
 
     test_pyc = my_dir + "/../test/bytecode_2.7/01_dead_code.pyc"
-    (version, timestamp, magic_int, co, pypy, source_size, _) = load_module(test_pyc)
-    code = co.co_consts[0]
+    module = load_module(test_pyc)
+    code = module.co.co_consts[0]
     offsets = opcode_27.get_jump_targets(code, opcode_27)
     assert [10] == offsets
 
@@ -156,8 +156,8 @@ def findlabels():
     # Python 3.6 code wordcode
     # ------------------------
     test_pyc = my_dir + "/../test/bytecode_3.6/01_dead_code.pyc"
-    (version, timestamp, magic_int, co, pypy, source_size, _) = load_module(test_pyc)
-    code = co.co_consts[0]
+    module = load_module(test_pyc)
+    code = module.co.co_consts[0]
 
     #  2:           0 LOAD_FAST                 0 (a)
     #               2 POP_JUMP_IF_FALSE         8 (to 8)

--- a/pytest/test_load_file.py
+++ b/pytest/test_load_file.py
@@ -25,23 +25,14 @@ def test_load_file() -> None:
 
     co_file = load_file(load_py)
     obj_path = check_object_path(load_py)
-    (
-        version_tuple,
-        _timestamp,
-        _magic_int,
-        co_module,
-        pypy,
-        source_size,
-        sip_hash,
-        _file_offsets,
-    ) = load_module(obj_path)
-    if (3, 3) <= version_tuple <= (3, 7):
+    module = load_module(obj_path)
+    if (3, 3) <= module.tuple_version <= (3, 7):
         statinfo = os.stat(load_py)
-        assert statinfo.st_size == source_size
-        assert sip_hash is None
-    elif version_tuple < (3, 3):
-        assert source_size is None, source_size
-        assert sip_hash is None
+        assert statinfo.st_size == module.source_size
+        assert module.sip_hash is None
+    elif module.tuple_version < (3, 3):
+        assert module.source_size is None, module.source_size
+        assert module.sip_hash is None
 
     # FIXME: put in xdis code somewhere
     if IS_GRAAL:
@@ -66,10 +57,10 @@ def test_load_file() -> None:
         if field == "co_lnotab" and PYTHON_VERSION_TRIPLE >= (3, 11):
             continue
         if hasattr(co_file, field):
-            if field == "co_code" and (pypy or IS_PYPY):
+            if field == "co_code" and (module.is_pypy or IS_PYPY):
                 continue
             load_file_field = getattr(co_file, field)
-            load_module_field = getattr(co_module, field)
+            load_module_field = getattr(module.co, field)
             if os.name == "windows" and field == "co_filename":
                 # MS/Windows is letter case insensitive
                 load_module_field = load_module_field.upper()

--- a/xdis/load.py
+++ b/xdis/load.py
@@ -13,6 +13,8 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from __future__ import annotations
+
 import marshal
 import os.path as osp
 import py_compile
@@ -24,7 +26,6 @@ from datetime import datetime
 from os import close
 from struct import pack, unpack
 from types import CodeType
-from typing import Tuple, Dict
 
 import xdis.marsh
 import xdis.unmarshal
@@ -50,14 +51,14 @@ from xdis.version_info import PYTHON3, PYTHON_VERSION_TRIPLE, PythonImplementati
 
 @dataclass
 class PycModuleInfo:
-    tuple_version: Tuple[int, int]
+    tuple_version: tuple[int, int, int]
     timestamp: int
     magic_int: int
     co: CodeBase
     is_pypy: bool
     source_size: int
     sip_hash: int = None
-    file_offsets: Dict = field(default_factory=dict)
+    file_offsets: dict = field(default_factory=dict)
 
 
 def is_python_source(path) -> bool:

--- a/xdis/load.py
+++ b/xdis/load.py
@@ -19,7 +19,7 @@ import py_compile
 import sys
 import tempfile
 import types
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from os import close
 from struct import pack, unpack

--- a/xdis/load.py
+++ b/xdis/load.py
@@ -19,13 +19,16 @@ import py_compile
 import sys
 import tempfile
 import types
+from dataclasses import dataclass
 from datetime import datetime
 from os import close
 from struct import pack, unpack
 from types import CodeType
+from typing import Tuple, Dict
 
 import xdis.marsh
 import xdis.unmarshal
+from xdis.codetype.base import CodeBase
 from xdis.dropbox.decrypt25 import fix_dropbox_pyc
 from xdis.magics import (
     GRAAL3_MAGICS,
@@ -42,6 +45,19 @@ from xdis.magics import (
     versions,
 )
 from xdis.version_info import PYTHON3, PYTHON_VERSION_TRIPLE, PythonImplementation
+
+
+
+@dataclass
+class PycModuleInfo:
+    tuple_version: Tuple[int, int]
+    timestamp: int
+    magic_int: int
+    co: CodeBase
+    is_pypy: bool
+    source_size: int
+    sip_hash: int = None
+    file_offsets: Dict = field(default_factory=dict)
 
 
 def is_python_source(path) -> bool:
@@ -148,7 +164,7 @@ def load_module(
     fast_load: bool = False,
     get_code: bool = True,
     save_file_offsets: bool = False,
-):
+) -> PycModuleInfo:
     """load a module without importing it.
     Parameters:
        filename:    name of file containing Python byte-code object
@@ -182,6 +198,8 @@ def load_module(
         sip_hash   : the SIP Hash for the file (only in Python 3.7 or greater), if the file
                      was created with a SIP hash or None otherwise. Note that if the sip_hash is not
                      none, then the timestamp and source_size will be invalid.
+
+    :rtype: PycModuleInfo
     """
 
     # Some sanity checks
@@ -213,10 +231,11 @@ def load_module_from_file_object(
     fast_load=False,
     get_code=True,
     save_file_offsets=False,
-):
+) -> PycModuleInfo:
     """load a module from a file object without importing it.
 
-    See :func:load_module for a list of return values.
+    :return: Module information, see :func:load_module for detailed information
+    :rtype: PycModuleInfo
     """
 
     if code_objects is None:
@@ -378,7 +397,7 @@ def load_module_from_file_object(
     if hasattr(co, "version_triple") and co.version_triple != (0, 0, 0):
         version_triple = co.version_triple
 
-    return (
+    return PycModuleInfo(
         version_triple,
         timestamp,
         magic_int,


### PR DESCRIPTION
Suggesting changing the returned tuple of information into an object, e.g. `PycModuleInfo`. This will enable adding additional fields in the future without introducing a breaking change on returned information from `load_module_from_file_object` and `load_module`.