### PR TITLE
Expose `xdis.std.stack_effect`

### DIFF
--- a/xdis/std.py
+++ b/xdis/std.py
@@ -304,3 +304,4 @@ disco = _std_api.disco
 get_instructions = _std_api.get_instructions
 findlinestarts = _std_api.findlinestarts
 findlabels = _std_api.findlabels
+stack_effect = _std_api.stack_effect


### PR DESCRIPTION
`xdis.std` is supposed to be a drop-in replacement for `dis`, but `xdis.std.stack_effect` is not exposed and must be accessed via `xdis.std._std_api.stack_effect` instead. 

This PR adds it to the `xdis.std` exports as `xdis.std.stack_effect` alongside other `dis`-compatible standard API methods.  

This closes #188. 