### PR TITLE
add missing call intrinsic 2 function

### DIFF
--- a/xdis/opcodes/opcode_3x/opcode_313.py
+++ b/xdis/opcodes/opcode_3x/opcode_313.py
@@ -517,6 +517,8 @@ def extended_format_CALL(opc, instructions) -> Tuple[str, Optional[int]]:
 
     return NULL_EXTENDED_OP
 
+### update CALL_INTRINSIC_2 function
+opcode_312._intrinsic_2_descs.append("INTRINSIC_SET_TYPEPARAM_DEFAULT")
 
 ### update formatting
 opcode_arg_fmt = opcode_arg_fmt313 = {


### PR DESCRIPTION
This binary function was added in 3.13  

https://github.com/python/cpython/blob/0293eacc248421de3f87ba13ead53e7184a81697/Include/internal/pycore_intrinsics.h#L32

This is probably not the best way to add this, but the alternative was adding it into the list in opcode_312.py which could cause a silent failure. 