### PR TITLE
Fix LOAD_COMMON_CONSTANT argrepr behavior on 3.15

### DIFF
--- a/pytest/test_instructions.py
+++ b/pytest/test_instructions.py
@@ -1,11 +1,43 @@
 """xdis.bytecode testing"""
+import dis
 import sys
 
 import pytest
 from xdis import IS_GRAAL, IS_PYPY
 from xdis.bytecode import Bytecode
 from xdis.op_imports import get_opcode_module
-from xdis.version_info import PYTHON_VERSION_TRIPLE
+from xdis.version_info import PYTHON_IMPLEMENTATION, PYTHON_VERSION_TRIPLE
+
+
+@pytest.mark.skipif(
+    IS_PYPY or PYTHON_VERSION_TRIPLE[:2] not in ((3, 14), (3, 15)),
+    reason="LOAD_COMMON_CONSTANT is specific to CPython 3.14 and 3.15",
+)
+def test_load_common_constant_argval_matches_dis() -> None:
+    codes = [
+        compile(source, "<test>", "exec")
+        for source in (
+            "assert False",
+            'result = {"success": True, "failure": False}',
+        )
+    ]
+
+    native = [
+        (inst.arg, inst.argval, inst.argrepr)
+        for code in codes
+        for inst in dis.get_instructions(code)
+        if inst.opname == "LOAD_COMMON_CONSTANT"
+    ]
+    cross = [
+        (inst.arg, inst.argval, inst.argrepr)
+        for code in codes
+        for inst in Bytecode(
+            code, get_opcode_module(PYTHON_VERSION_TRIPLE, PYTHON_IMPLEMENTATION)
+        )
+        if inst.opname == "LOAD_COMMON_CONSTANT"
+    ]
+
+    assert cross == native
 
 
 def extended_arg_fn36() -> int:

--- a/xdis/bytecode.py
+++ b/xdis/bytecode.py
@@ -433,6 +433,8 @@ def get_logical_instruction_at_offset(
                         )
             if hasattr(opc, "opcode_arg_fmt") and opname in opc.opcode_arg_fmt:
                 argrepr = opc.opcode_arg_fmt[opname](arg)
+            if hasattr(opc, "opcode_arg_val") and opname in opc.opcode_arg_val:
+                argval = opc.opcode_arg_val[opname](arg)
         else:
             if fixed_length_instructions:
                 i += 1

--- a/xdis/opcodes/opcode_3x/opcode_314.py
+++ b/xdis/opcodes/opcode_3x/opcode_314.py
@@ -377,8 +377,6 @@ opcode_arg_fmt = opcode_arg_fmt314 = {
     **{"LOAD_COMMON_CONSTANT": format_LOAD_COMMON_CONSTANT_314},
 }
 
-opcode_arg_val = opcode_arg_val314 = {}
-
 opcode_extended_fmt = opcode_extended_fmt314 = {
     **opcode_313.opcode_extended_fmt313,
     **{"BINARY_OP": extended_BINARY_OP_314},

--- a/xdis/opcodes/opcode_3x/opcode_314.py
+++ b/xdis/opcodes/opcode_3x/opcode_314.py
@@ -377,6 +377,8 @@ opcode_arg_fmt = opcode_arg_fmt314 = {
     **{"LOAD_COMMON_CONSTANT": format_LOAD_COMMON_CONSTANT_314},
 }
 
+opcode_arg_val = opcode_arg_val314 = {}
+
 opcode_extended_fmt = opcode_extended_fmt314 = {
     **opcode_313.opcode_extended_fmt313,
     **{"BINARY_OP": extended_BINARY_OP_314},

--- a/xdis/opcodes/opcode_3x/opcode_315.py
+++ b/xdis/opcodes/opcode_3x/opcode_315.py
@@ -373,24 +373,29 @@ def extended_BINARY_OP_315(opc, instructions):
 
 
 _common_constants = (
-    "AssertionError",
-    "NotImplementedError",
-    "tuple",
-    "all",
-    "any",
-    "list",
-    "set",
-    "None",        # <--- There is your oparg 7!
-    '""',
-    "True",
-    "False",
-    "-1",
-    "frozenset",
-    "()",
+    AssertionError,
+    NotImplementedError,
+    tuple,
+    all,
+    any,
+    list,
+    set,
+    None,
+    "",
+    True,
+    False,
+    -1,
+    frozenset,
+    (),
 )
 
 
 def format_LOAD_COMMON_CONSTANT_315(arg: int):
+    obj = _common_constants[arg]
+    return obj.__name__ if isinstance(obj, type) else repr(obj)
+
+
+def resolve_LOAD_COMMON_CONSTANT_315(arg: int):
     return _common_constants[arg]
 
 
@@ -398,6 +403,11 @@ opcode_arg_fmt = opcode_arg_fmt315 = {
     **opcode_314.opcode_arg_fmt314,
     **{"BINARY_OP": format_BINARY_OP_315},
     **{"LOAD_COMMON_CONSTANT": format_LOAD_COMMON_CONSTANT_315},
+}
+
+opcode_arg_val = opcode_arg_val315 = {
+    **opcode_314.opcode_arg_val314,
+    **{"LOAD_COMMON_CONSTANT": resolve_LOAD_COMMON_CONSTANT_315},
 }
 
 opcode_extended_fmt = opcode_extended_fmt315 = {

--- a/xdis/opcodes/opcode_3x/opcode_315.py
+++ b/xdis/opcodes/opcode_3x/opcode_315.py
@@ -406,8 +406,7 @@ opcode_arg_fmt = opcode_arg_fmt315 = {
 }
 
 opcode_arg_val = opcode_arg_val315 = {
-    **opcode_314.opcode_arg_val314,
-    **{"LOAD_COMMON_CONSTANT": resolve_LOAD_COMMON_CONSTANT_315},
+    "LOAD_COMMON_CONSTANT": resolve_LOAD_COMMON_CONSTANT_315,
 }
 
 opcode_extended_fmt = opcode_extended_fmt315 = {


### PR DESCRIPTION
On 3.15, `argrepr` in `dis` has been adjusted to the actual `LOAD_COMMON_CONSTANT` values, unlike 3.14 where they are still integers. This causes a parity mismatch between `xdis` and `dis` on 3.15. 

This PR fixes this parity issue by adding a hook in `bytecode.py` and updating `opcode_315.py` to use `LOAD_COMMON_CONSTANT` values for `argval`, and changing `argrepr` to use `repr(argval)` to avoid the need for 2 `LOAD_COMMON_CONSTANT` tables.

## Issue reproduction
```py
import dis
import sys
from xdis import Bytecode, get_opcode

code = compile(
    'result = {"success": True, "failure": False}',
    "<test>",
    "exec",
)

native = [
    (inst.arg, inst.argval, inst.argrepr)
    for inst in dis.get_instructions(code)
    if inst.opname == "LOAD_COMMON_CONSTANT"
]
cross = [
    (inst.arg, inst.argval, inst.argrepr)
    for inst in Bytecode(code, get_opcode(sys.version_info[:2], False))
    if inst.opname == "LOAD_COMMON_CONSTANT"
]

print("dis:", native)
print("xdis:", cross)
```

Output on 3.15:
```
dis:  [(9, True, 'True'), (10, False, 'False'), (7, None, 'None')]
xdis: [(9, 9, 'True'), (10, 10, 'False'), (7, 7, 'None')]
```
